### PR TITLE
Update plugins vim-airline-themes & ctrlp

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -7,11 +7,12 @@ set runtimepath+=~/.vim/bundle/Vundle.vim
 call vundle#begin()
 
 Plugin 'bling/vim-airline'
+Plugin 'vim-airline/vim-airline-themes'
 Plugin 'bogado/file-line'
 Plugin 'gmarik/Vundle.vim'
 Plugin 'godlygeek/tabular'
 Plugin 'junegunn/limelight.vim'
-Plugin 'kien/ctrlp.vim'
+Plugin 'ctrlpvim/ctrlp.vim'
 Plugin 'majutsushi/tagbar'
 Plugin 'maxbrunsfeld/vim-yankstack'
 Plugin 'scrooloose/nerdcommenter'


### PR DESCRIPTION
Suggested changes:
- Ctrlp has in [kien/ctrlp](https://github.com/kien/ctrlp.vim) is no longer maintained. [Ctrlpvim/ctrlp](https://github.com/ctrlpvim/ctrlp.vim) is the actively maintained fork now.
- vim-airline-themes has been separated from the vim-airline repo. Read more [here](https://github.com/vim-airline/vim-airline#themes) 
